### PR TITLE
ci: pin gha versions and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
 
       - name:                 Cancel Previous Runs
-        uses:                 styfle/cancel-workflow-action@0.9.1
+        uses:                 styfle/cancel-workflow-action@bb6001c4ea612bf59c3abfc4756fbceee4f870c7 # 0.10.0
         with:
           access_token:       ${{ github.token }}
 
       - name:                 Checkout sources
-        uses:                 actions/checkout@v2.4.0
+        uses:                 actions/checkout@v3
         with:
           fetch-depth:        50
           submodules:         'recursive'
@@ -32,7 +32,7 @@ jobs:
           override:           true
 
       - name:                 Rust Cache
-        uses:                 Swatinem/rust-cache@v1.3.0
+        uses:                 Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0
         with:
           working-directory:  .
 

--- a/.github/workflows/rust-fmt.yml
+++ b/.github/workflows/rust-fmt.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
 
       - name:                 Cancel Previous Runs
-        uses:                 styfle/cancel-workflow-action@0.9.1
+        uses:                 styfle/cancel-workflow-action@bb6001c4ea612bf59c3abfc4756fbceee4f870c7 # 0.10.0
         with:
           access_token:       ${{ github.token }}
 
       - name:                 Checkout sources
-        uses:                 actions/checkout@v2.4.0
+        uses:                 actions/checkout@v3
         with:
           fetch-depth:        50
           submodules:         'recursive'

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
 
       - name:                 Cancel Previous Runs
-        uses:                 styfle/cancel-workflow-action@0.9.1
+        uses:                 styfle/cancel-workflow-action@bb6001c4ea612bf59c3abfc4756fbceee4f870c7 # 0.10.0
         with:
           access_token:       ${{ github.token }}
 
       - name:                 Checkout sources
-        uses:                 actions/checkout@v2.4.0
+        uses:                 actions/checkout@v3
         with:
           fetch-depth:        50
           submodules:         'recursive'
@@ -32,13 +32,13 @@ jobs:
           override:           true
 
       - name:                 Install cargo-nextest
-        uses:                 baptiste0928/cargo-install@v1
+        uses:                 baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0
         with:
           crate:              cargo-nextest
           version:            0.9
 
       - name:                 Rust Cache
-        uses:                 Swatinem/rust-cache@v1.3.0
+        uses:                 Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0
         with:
           working-directory:  .
 


### PR DESCRIPTION
In order to improve our security posture with GitHub Actions usage. I've made a version pinning ether to commit hash or to specific version.
Additionally added `dependabot` to track GHA version changes.
Related issues and policy:
https://github.com/paritytech/ci_cd/issues/114
https://github.com/paritytech/ci_cd/issues/464
https://github.com/paritytech/ci_cd/wiki/Policies-and-regulations:-GitHub-Actions-usage-policies